### PR TITLE
Enable include files via package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Node.js API (N-API).
 To use these headers in a native module:
   1. Add a dependency on this package to `package.json`.
   2. Reference this package's include directory in `binding.gyp`:
-```json
+```gyp
 {
   'target_name': 'example_module',
   'include_dirs': ["<!(node -p \"require('node-api').include\")"],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
-# Node.js API (NAPI) C++ Wrapper
+# Node.js API (N-API) Package
 
-This repo contains header-only C++ wrapper classes for the C APIs for the ABI Stable Node API project (NAPI).
+This package contains header-only C++ wrapper classes for the ABI-stable
+Node.js API (N-API).
 
-See the [main project README](https://github.com/nodejs/abi-stable-node/blob/doc/README.md) for more details.
+To use these headers in a native module:
+  1. Add a dependency on this package to `package.json`.
+  2. Reference this package's include directory in `binding.gyp`:
+```json
+{
+  'target_name': 'example_module',
+  'include_dirs': ["<!(node -p \"require('node-api').include\")"],
+}
+```
+
+Eventually this package will also contain library code that enables
+backward-compatibility with use with older versions of Node.js that do
+not have N-API built-in.
+
+See the [main project README](
+   https://github.com/nodejs/abi-stable-node/blob/doc/README.md)
+for more details.

--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,0 +1,1 @@
+console.log(require('path').relative('.', __dirname));

--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,1 +1,0 @@
-console.log(require('path').relative('.', __dirname));

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+const include = __dirname;
+const isNodeApiBuiltin = process.versions.modules >= 52;
+
+module.exports = {
+   include: include,
+   isNodeApiBuiltin: isNodeApiBuiltin,
+};

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "bugs": {
-    "url": "https://github.com/nodejs/abi-stable-node-wrapper/issues"
+    "url": "https://github.com/nodejs/node-api/issues"
   },
   "dependencies": {},
   "description": "Node.js API (N-API)",
   "devDependencies": {
   },
   "directories": {},
-  "homepage": "https://github.com/nodejs/abi-stable-node-wrapper",
+  "homepage": "https://github.com/nodejs/node-api",
   "license": "MIT",
   "main": "index.js",
   "name": "node-api",
@@ -15,7 +15,7 @@
   "readme": "README.md",
   "repository": {
     "type": "git",
-    "url": "git://github.com/nodejs/abi-stable-node-wrapper.git"
+    "url": "git://github.com/nodejs/node-api.git"
   },
   "scripts": {
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "bugs": {
+    "url": "https://github.com/nodejs/abi-stable-node-wrapper/issues"
+  },
+  "dependencies": {},
+  "description": "Node.js API (NAPI) C++ Wrapper",
+  "devDependencies": {
+  },
+  "directories": {},
+  "homepage": "https://github.com/nodejs/abi-stable-node-wrapper",
+  "license": "MIT",
+  "main": "include_dirs.js",
+  "name": "napi",
+  "optionalDependencies": {},
+  "readme": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nodejs/abi-stable-node-wrapper.git"
+  },
+  "scripts": {
+  },
+  "version": "0.1.0"
+}

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
     "url": "https://github.com/nodejs/abi-stable-node-wrapper/issues"
   },
   "dependencies": {},
-  "description": "Node.js API (NAPI) C++ Wrapper",
+  "description": "Node.js API (N-API)",
   "devDependencies": {
   },
   "directories": {},
   "homepage": "https://github.com/nodejs/abi-stable-node-wrapper",
   "license": "MIT",
-  "main": "include_dirs.js",
-  "name": "napi",
+  "main": "index.js",
+  "name": "node-api",
   "optionalDependencies": {},
   "readme": "README.md",
   "repository": {


### PR DESCRIPTION
This enables other packages to get the N-API headers via a package dependency, the same way that NAN works. The header files would be referenced like this in `binding.gyp`: 
```json
  'include_dirs': ["<!(node -p \"require('node-api').include\")"],
```

The same mechanism can be used in the future to enable referencing other things from the package like a static lib or maybe a gyp dependency, when we add the source code for back-compat.

Currently I've set a package name of **node-api**, with the expectation that we'll be able to [acquire that package name](https://github.com/laurie71/node-api/issues/2).