### PR TITLE
Updates for N-API changes

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -11,19 +11,24 @@
 
 namespace Napi {
 
-// Adapt the NODE_MODULE registration function to NAPI:
+// Adapt the NAPI_MODULE registration function:
 //  - Wrap the arguments in NAPI wrappers.
 //  - Catch any NAPI errors that might be thrown.
-#define NAPI_MODULE(modname, regfunc)                                                 \
-  void __napi_ ## regfunc(napi_env env, napi_value exports, napi_value module) {      \
-    try {                                                                             \
-      regfunc(Napi::Env(env), Napi::Object(env, exports), Napi::Object(env, module)); \
-    }                                                                                 \
-    catch (const Napi::Error&) {                                                      \
-      assert(false); /* Uncaught error in native module registration. */              \
-    }                                                                                 \
-  }                                                                                   \
-  NODE_MODULE_ABI(modname, __napi_ ## regfunc);
+#define NODE_API_MODULE(modname, regfunc)                                \
+  void __napi_ ## regfunc(napi_env env,                                  \
+                          napi_value exports,                            \
+                          napi_value module,                             \
+                          void* priv) {                                  \
+    try {                                                                \
+      regfunc(Napi::Env(env),                                            \
+              Napi::Object(env, exports),                                \
+              Napi::Object(env, module));                                \
+    }                                                                    \
+    catch (const Napi::Error&) {                                         \
+      assert(false); /* Uncaught error in native module registration. */ \
+    }                                                                    \
+  }                                                                      \
+  NAPI_MODULE(modname, __napi_ ## regfunc);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,30 +68,6 @@ inline bool Env::IsExceptionPending() const {
   napi_status status = napi_is_exception_pending(_env, &result);
   if (status != napi_ok) result = false; // Checking for a pending exception shouldn't throw.
   return result;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// PropertyName class
-////////////////////////////////////////////////////////////////////////////////
-
-inline PropertyName::PropertyName(napi_env env, napi_propertyname name) : _env(env), _name(name) {
-}
-
-inline PropertyName::PropertyName(napi_env env, const char* utf8name) : _env(env) {
-  napi_status status = napi_property_name(env, utf8name, &_name);
-  if (status != napi_ok) throw Error::New(_env);
-}
-
-inline PropertyName::PropertyName(napi_env env, const std::string& utf8name)
-  : PropertyName(env, utf8name.c_str()) {
-}
-
-inline PropertyName::operator napi_propertyname() const {
-  return _name;
-}
-
-inline Env PropertyName::Env() const {
-  return Napi::Env(_env);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -424,7 +405,14 @@ inline Value Object::operator [](uint32_t index) const {
   return Get(index);
 }
 
-inline bool Object::Has(napi_propertyname name) const {
+inline bool Object::Has(napi_value name) const {
+  bool result;
+  napi_status status = napi_has_property(_env, _value, name, &result);
+  if (status != napi_ok) throw Error::New(_env);
+  return result;
+}
+
+inline bool Object::Has(Value name) const {
   bool result;
   napi_status status = napi_has_property(_env, _value, name, &result);
   if (status != napi_ok) throw Error::New(_env);
@@ -432,14 +420,24 @@ inline bool Object::Has(napi_propertyname name) const {
 }
 
 inline bool Object::Has(const char* utf8name) const {
-  return Has(PropertyName(_env, utf8name));
+  bool result;
+  napi_status status = napi_has_named_property(_env, _value, utf8name, &result);
+  if (status != napi_ok) throw Error::New(Env());
+  return result;
 }
 
 inline bool Object::Has(const std::string& utf8name) const {
-  return Has(PropertyName(_env, utf8name));
+  return Has(utf8name.c_str());
 }
 
-inline Value Object::Get(napi_propertyname name) const {
+inline Value Object::Get(napi_value name) const {
+  napi_value result;
+  napi_status status = napi_get_property(_env, _value, name, &result);
+  if (status != napi_ok) throw Error::New(_env);
+  return Value(_env, result);
+}
+
+inline Value Object::Get(Value name) const {
   napi_value result;
   napi_status status = napi_get_property(_env, _value, name, &result);
   if (status != napi_ok) throw Error::New(_env);
@@ -447,48 +445,61 @@ inline Value Object::Get(napi_propertyname name) const {
 }
 
 inline Value Object::Get(const char* utf8name) const {
-  return Get(PropertyName(_env, utf8name));
+  napi_value result;
+  napi_status status = napi_get_named_property(_env, _value, utf8name, &result);
+  if (status != napi_ok) throw Error::New(Env());
+  return Value(_env, result);
 }
 
 inline Value Object::Get(const std::string& utf8name) const {
-  return Get(PropertyName(_env, utf8name));
+  return Get(utf8name.c_str());
 }
 
-inline void Object::Set(napi_propertyname name, napi_value value) {
+inline void Object::Set(napi_value name, napi_value value) {
   napi_status status = napi_set_property(_env, _value, name, value);
   if (status != napi_ok) throw Error::New(_env);
 }
 
+inline void Object::Set(const char* utf8name, Value value) {
+  napi_status status = napi_set_named_property(_env, _value, utf8name, value);
+  if (status != napi_ok) throw Error::New(Env());
+}
+
 inline void Object::Set(const char* utf8name, napi_value value) {
-  Set(PropertyName(_env, utf8name), value);
+  napi_status status = napi_set_named_property(_env, _value, utf8name, value);
+  if (status != napi_ok) throw Error::New(Env());
 }
 
 inline void Object::Set(const char* utf8name, const char* utf8value) {
-  Set(PropertyName(_env, utf8name), String::New(Env(), utf8value));
+  Set(utf8name, String::New(Env(), utf8value));
 }
 
 inline void Object::Set(const char* utf8name, bool boolValue) {
-  Set(PropertyName(_env, utf8name), Boolean::New(Env(), boolValue));
+  Set(utf8name, Boolean::New(Env(), boolValue));
 }
 
 inline void Object::Set(const char* utf8name, double numberValue) {
-  Set(PropertyName(_env, utf8name), Number::New(Env(), numberValue));
+  Set(utf8name, Number::New(Env(), numberValue));
 }
 
 inline void Object::Set(const std::string& utf8name, napi_value value) {
-  Set(PropertyName(_env, utf8name), value);
+  Set(utf8name.c_str(), value);
+}
+
+inline void Object::Set(const std::string& utf8name, Value value) {
+  Set(utf8name.c_str(), value);
 }
 
 inline void Object::Set(const std::string& utf8name, std::string& utf8value) {
-  Set(PropertyName(_env, utf8name), String::New(Env(), utf8value));
+  Set(utf8name.c_str(), String::New(Env(), utf8value));
 }
 
 inline void Object::Set(const std::string& utf8name, bool boolValue) {
-  Set(PropertyName(_env, utf8name), Boolean::New(Env(), boolValue));
+  Set(utf8name.c_str(), Boolean::New(Env(), boolValue));
 }
 
 inline void Object::Set(const std::string& utf8name, double numberValue) {
-  Set(PropertyName(_env, utf8name), Number::New(Env(), numberValue));
+  Set(utf8name.c_str(), Number::New(Env(), numberValue));
 }
 
 inline bool Object::Has(uint32_t index) const {
@@ -506,6 +517,11 @@ inline Value Object::Get(uint32_t index) const {
 }
 
 inline void Object::Set(uint32_t index, napi_value value) {
+  napi_status status = napi_set_element(_env, _value, index, value);
+  if (status != napi_ok) throw Error::New(_env);
+}
+
+inline void Object::Set(uint32_t index, Value value) {
   napi_status status = napi_set_element(_env, _value, index, value);
   if (status != napi_ok) throw Error::New(_env);
 }
@@ -555,26 +571,29 @@ inline bool Object::InstanceOf(const Function& constructor) const {
 // External class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline External External::New(napi_env env, void* data, napi_finalize finalizeCallback) {
+template <typename T>
+inline External<T> External<T>::New(
+    napi_env env, T* data, napi_finalize finalizeCallback, void* finalizeHint) {
   napi_value value;
-  napi_status status = napi_create_external(env, data, finalizeCallback, &value);
+  napi_status status = napi_create_external(env, data, finalizeCallback, finalizeHint, &value);
   if (status != napi_ok) throw Error::New(env);
   return External(env, value);
 }
 
-inline External::External() : Value() {
-
+template <typename T>
+inline External<T>::External() : Value() {
 }
 
-inline External::External(napi_env env, napi_value value) : Value(env, value) {
-
+template <typename T>
+inline External<T>::External(napi_env env, napi_value value) : Value(env, value) {
 }
 
-inline void* External::Data() const {
+template <typename T>
+inline T* External<T>::Data() const {
   void* data;
   napi_status status = napi_get_value_external(_env, _value, &data);
   if (status != napi_ok) throw Error::New(_env);
-  return data;
+  return reinterpret_cast<T*>(data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -627,10 +646,11 @@ inline ArrayBuffer ArrayBuffer::New(napi_env env, size_t byteLength) {
 inline ArrayBuffer ArrayBuffer::New(napi_env env,
                                     void* externalData,
                                     size_t byteLength,
-                                    napi_finalize finalizeCallback) {
+                                    napi_finalize finalizeCallback,
+                                    void* finalizeHint) {
   napi_value value;
   napi_status status = napi_create_external_arraybuffer(
-    env, externalData, byteLength, finalizeCallback, &value);
+    env, externalData, byteLength, finalizeCallback, finalizeHint, &value);
   if (status != napi_ok) throw Error::New(env);
 
   ArrayBuffer arrayBuffer(env, value);
@@ -1007,10 +1027,10 @@ inline Buffer<T> Buffer<T>::New(napi_env env, size_t length) {
 
 template <typename T>
 inline Buffer<T> Buffer<T>::New(
-    napi_env env, T* data, size_t length, napi_finalize finalizeCallback) {
+    napi_env env, T* data, size_t length, napi_finalize finalizeCallback, void* finalizeHint) {
   napi_value value;
   napi_status status = napi_create_external_buffer(
-    env, length * sizeof (T), data, finalizeCallback, &value);
+    env, length * sizeof (T), data, finalizeCallback, finalizeHint, &value);
   if (status != napi_ok) throw Error::New(env);
   return Buffer(env, value, length, data);
 }
@@ -1399,6 +1419,11 @@ inline void ObjectReference::Set(const char* utf8name, napi_value value) {
   Value().Set(utf8name, value);
 }
 
+inline void ObjectReference::Set(const char* utf8name, Napi::Value value) {
+  HandleScope scope(_env);
+  Value().Set(utf8name, value);
+}
+
 inline void ObjectReference::Set(const char* utf8name, const char* utf8value) {
   HandleScope scope(_env);
   Value().Set(utf8name, utf8value);
@@ -1415,6 +1440,11 @@ inline void ObjectReference::Set(const char* utf8name, double numberValue) {
 }
 
 inline void ObjectReference::Set(const std::string& utf8name, napi_value value) {
+  HandleScope scope(_env);
+  Value().Set(utf8name, value);
+}
+
+inline void ObjectReference::Set(const std::string& utf8name, Napi::Value value) {
   HandleScope scope(_env);
   Value().Set(utf8name, value);
 }
@@ -1440,6 +1470,11 @@ inline Napi::Value ObjectReference::Get(uint32_t index) const {
 }
 
 inline void ObjectReference::Set(uint32_t index, napi_value value) {
+  HandleScope scope(_env);
+  Value().Set(index, value);
+}
+
+inline void ObjectReference::Set(uint32_t index, Napi::Value value) {
   HandleScope scope(_env);
   Value().Set(index, value);
 }
@@ -1819,7 +1854,7 @@ inline void ObjectWrap<T>::ConstructorCallbackWrapper(
   }
 
   napi_ref ref;
-  status = napi_wrap(env, wrapper, instance, FinalizeCallback, &ref);
+  status = napi_wrap(env, wrapper, instance, FinalizeCallback, nullptr, &ref);
   if (status != napi_ok) return;
 
   Reference<Object>* instanceRef = instance;
@@ -1998,7 +2033,7 @@ inline void ObjectWrap<T>::InstanceSetterCallbackWrapper(
 }
 
 template <typename T>
-inline void ObjectWrap<T>::FinalizeCallback(void* data) {
+inline void ObjectWrap<T>::FinalizeCallback(void* data, void* /*hint*/) {
   T* instance = reinterpret_cast<T*>(data);
   delete instance;
 }

--- a/napi.h
+++ b/napi.h
@@ -18,6 +18,7 @@
 
 namespace Napi {
 
+  class Env;
   class Value;
   class Boolean;
   class Number;
@@ -48,6 +49,9 @@ namespace Napi {
   // (See ObjectWrap<T> for callbacks used when wrapping entire classes.)
   typedef std::function<void(const CallbackInfo& info)> VoidFunctionCallback;
   typedef std::function<Value(const CallbackInfo& info)> FunctionCallback;
+
+  // A N-API C++ module's registration callback (init) function has this sinature.
+  typedef void ModuleRegisterCallback(Env env, Object exports, Object module);
 
   /*
    * Environment for NAPI operations. (In V8 this corresponds to an Isolate.)

--- a/napi.h
+++ b/napi.h
@@ -9,8 +9,8 @@
 // The wrappers are all header-only so that they do not affect the ABI.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "node_jsvmapi.h"
-#include "node_asyncapi.h"
+#include "node_api.h"
+#include "node_api_async.h"
 #include <functional>
 #include <initializer_list>
 #include <string>
@@ -66,21 +66,6 @@ namespace Napi {
 
   private:
     napi_env _env;
-  };
-
-  class PropertyName {
-  public:
-    PropertyName(napi_env env, napi_propertyname name);
-    PropertyName(napi_env env, const char* utf8name);
-    PropertyName(napi_env env, const std::string& utf8name);
-
-    operator napi_propertyname() const;
-
-    Env Env() const;
-
-  private:
-    napi_env _env;
-    napi_propertyname _name;
   };
 
   /*
@@ -189,18 +174,22 @@ namespace Napi {
     Value operator [](const std::string& name) const;
     Value operator [](uint32_t index) const;
 
-    bool Has(napi_propertyname name) const;
+    bool Has(napi_value name) const;
+    bool Has(Value name) const;
     bool Has(const char* utf8name) const;
     bool Has(const std::string& utf8name) const;
-    Value Get(napi_propertyname name) const;
+    Value Get(napi_value name) const;
+    Value Get(Value name) const;
     Value Get(const char* utf8name) const;
     Value Get(const std::string& utf8name) const;
-    void Set(napi_propertyname name, napi_value value);
+    void Set(napi_value name, napi_value value);
     void Set(const char* utf8name, napi_value value);
+    void Set(const char* utf8name, Value value);
     void Set(const char* utf8name, const char* utf8value);
     void Set(const char* utf8name, bool boolValue);
     void Set(const char* utf8name, double numberValue);
     void Set(const std::string& utf8name, napi_value value);
+    void Set(const std::string& utf8name, Value value);
     void Set(const std::string& utf8name, std::string& utf8value);
     void Set(const std::string& utf8name, bool boolValue);
     void Set(const std::string& utf8name, double numberValue);
@@ -208,6 +197,7 @@ namespace Napi {
     bool Has(uint32_t index) const;
     Value Get(uint32_t index) const;
     void Set(uint32_t index, napi_value value);
+    void Set(uint32_t index, Value value);
     void Set(uint32_t index, const char* utf8value);
     void Set(uint32_t index, const std::string& utf8value);
     void Set(uint32_t index, bool boolValue);
@@ -219,14 +209,18 @@ namespace Napi {
     bool InstanceOf(const Function& constructor) const;
   };
 
+  template <typename T>
   class External : public Value {
   public:
-    static External New(napi_env env, void* data, napi_finalize finalizeCallback = nullptr);
+    static External New(napi_env env,
+                        T* data,
+                        napi_finalize finalizeCallback = nullptr,
+                        void* finalizeHint = nullptr);
 
     External();
     External(napi_env env, napi_value value);
 
-    void* Data() const;
+    T* Data() const;
   };
 
   class Array : public Object {
@@ -246,7 +240,8 @@ namespace Napi {
     static ArrayBuffer New(napi_env env,
                            void* externalData,
                            size_t byteLength,
-                           napi_finalize finalizeCallback);
+                           napi_finalize finalizeCallback = nullptr,
+                           void* finalizeHint = nullptr);
 
     ArrayBuffer();
     ArrayBuffer(napi_env env, napi_value value);
@@ -372,7 +367,10 @@ namespace Napi {
   class Buffer : public Object {
   public:
     static Buffer<T> New(napi_env env, size_t length);
-    static Buffer<T> New(napi_env env, T* data, size_t length, napi_finalize finalizeCallback);
+    static Buffer<T> New(napi_env env, T* data,
+                         size_t length,
+                         napi_finalize finalizeCallback = nullptr,
+                         void* finalizeHint = nullptr);
     static Buffer<T> Copy(napi_env env, const T* data, size_t length);
 
     Buffer();
@@ -538,16 +536,19 @@ namespace Napi {
     Napi::Value Get(const char* utf8name) const;
     Napi::Value Get(const std::string& utf8name) const;
     void Set(const char* utf8name, napi_value value);
+    void Set(const char* utf8name, Napi::Value value);
     void Set(const char* utf8name, const char* utf8value);
     void Set(const char* utf8name, bool boolValue);
     void Set(const char* utf8name, double numberValue);
     void Set(const std::string& utf8name, napi_value value);
+    void Set(const std::string& utf8name, Napi::Value value);
     void Set(const std::string& utf8name, std::string& utf8value);
     void Set(const std::string& utf8name, bool boolValue);
     void Set(const std::string& utf8name, double numberValue);
 
     Napi::Value Get(uint32_t index) const;
     void Set(uint32_t index, const napi_value value);
+    void Set(uint32_t index, const Napi::Value value);
     void Set(uint32_t index, const char* utf8value);
     void Set(uint32_t index, const std::string& utf8value);
     void Set(uint32_t index, bool boolValue);
@@ -745,7 +746,7 @@ namespace Napi {
     static void InstanceMethodCallbackWrapper(napi_env env, napi_callback_info info);
     static void InstanceGetterCallbackWrapper(napi_env env, napi_callback_info info);
     static void InstanceSetterCallbackWrapper(napi_env env, napi_callback_info info);
-    static void FinalizeCallback(void* data);
+    static void FinalizeCallback(void* data, void* hint);
 
     typedef struct {
       union {


### PR DESCRIPTION
 - Remove the `PropertyName` class (wrapper around `napi_propertyname` type) and all uses of it.
 - Add overloads for `Has()`, `Get()`, `Set()` that take `napi_value` parameters as an alternative to strings.
 - Call the new `named_property` APIs where applicable.
 - Add overloads for `Set()` that take `Napi::Value` parameters as an alternative to `napi_value`. I don't entirely understand why this is necessary, but it eliminates some compiler errors about ambiguous overload resolution.
 - Make the `External` class templated on the type of external data that it holds.
 - Support finalize hints