### PR TITLE
Updates for N-API async changes

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1229,7 +1229,7 @@ inline RangeError::RangeError(napi_env env, napi_value value) : Error(env, value
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-inline Reference<T> Reference<T>::New(const T& value, int initialRefcount) {
+inline Reference<T> Reference<T>::New(const T& value, uint32_t initialRefcount) {
   napi_env env = value.Env();
   napi_value val = value;
 
@@ -1321,7 +1321,7 @@ inline T Reference<T>::Value() const {
 }
 
 template <typename T>
-inline int Reference<T>::Ref() {
+inline uint32_t Reference<T>::Ref() {
   uint32_t result;
   napi_status status = napi_reference_ref(_env, _ref, &result);
   if (status != napi_ok) throw Error::New(_env);
@@ -1329,7 +1329,7 @@ inline int Reference<T>::Ref() {
 }
 
 template <typename T>
-inline int Reference<T>::Unref() {
+inline uint32_t Reference<T>::Unref() {
   uint32_t result;
   napi_status status = napi_reference_unref(_env, _ref, &result);
   if (status != napi_ok) throw Error::New(_env);
@@ -1346,7 +1346,7 @@ inline void Reference<T>::Reset() {
 }
 
 template <typename T>
-inline void Reference<T>::Reset(const T& value, int refcount) {
+inline void Reference<T>::Reset(const T& value, uint32_t refcount) {
   Reset();
   _env = value.Env();
 

--- a/napi.h
+++ b/napi.h
@@ -491,7 +491,7 @@ namespace Napi {
   template <typename T>
   class Reference {
   public:
-    static Reference<T> New(const T& value, int initialRefcount = 0);
+    static Reference<T> New(const T& value, uint32_t initialRefcount = 0);
 
     Reference();
     Reference(napi_env env, napi_ref ref);
@@ -514,10 +514,10 @@ namespace Napi {
     // within a HandleScope so that the value handle gets cleaned up efficiently.
     T Value() const;
 
-    int Ref();
-    int Unref();
+    uint32_t Ref();
+    uint32_t Unref();
     void Reset();
-    void Reset(const T& value, int refcount = 0);
+    void Reset(const T& value, uint32_t refcount = 0);
 
     // Call this on a reference that is declared as static data, to prevent its destructor
     // from running at program shutdown time, which would attempt to reset the reference when


### PR DESCRIPTION
Updates for pending changes in async APIs at https://github.com/nodejs/abi-stable-node/pull/204, along with other recent changes.
 - Rename `napi_work` to `napi_async_work`
 - Async APIs all take an `env` parameter and return a `napi_status`
 - New `napi_cancel_async_work()` API
 - Track (a persistent reference to) an `Error` object for async work errors, rather than just an error message.
 - Error handling APIs all return a `napi_status`
 - Reference counts are unsigned