### PR TITLE
Make Function::New more usable, support obj[…] for writing and add a small test

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -425,6 +425,21 @@ inline std::u16string String::Utf16Value() const {
 // Object class
 ////////////////////////////////////////////////////////////////////////////////
 
+template <typename Key>
+inline PropertyLValue<Key>::operator Value() const {
+  return _object.Get(_key);
+}
+
+template <typename Key> template <typename ValueType>
+inline PropertyLValue<Key>& PropertyLValue<Key>::operator =(ValueType value) {
+  _object.Set(_key, value);
+  return *this;
+}
+
+template <typename Key>
+inline PropertyLValue<Key>::PropertyLValue(Object object, Key key)
+  : _object(object), _key(key) {}
+
 inline Object Object::New(napi_env env) {
   napi_value value;
   napi_status status = napi_create_object(env, &value);
@@ -436,6 +451,18 @@ inline Object::Object() : Value() {
 }
 
 inline Object::Object(napi_env env, napi_value value) : Value(env, value) {
+}
+
+inline PropertyLValue<std::string> Object::operator [](const char* name) {
+  return PropertyLValue<std::string>(*this, name);
+}
+
+inline PropertyLValue<std::string> Object::operator [](const std::string& name) {
+  return PropertyLValue<std::string>(*this, name);
+}
+
+inline PropertyLValue<uint32_t> Object::operator [](uint32_t index) {
+  return PropertyLValue<uint32_t>(*this, index);
 }
 
 inline Value Object::operator [](const char* name) const {

--- a/napi.h
+++ b/napi.h
@@ -36,6 +36,7 @@ namespace Napi {
   class PropertyDescriptor;
   class CallbackInfo;
   template <typename T> class Reference;
+  template <typename Key> class PropertyLValue;
 
   class TypedArray;
   template <typename T, napi_typedarray_type A> class TypedArray_;
@@ -175,6 +176,10 @@ namespace Napi {
     Object();
     Object(napi_env env, napi_value value);
 
+    PropertyLValue<std::string> operator [](const char* name);
+    PropertyLValue<std::string> operator [](const std::string& name);
+    PropertyLValue<uint32_t> operator [](uint32_t index);
+
     Value operator [](const char* name) const;
     Value operator [](const std::string& name) const;
     Value operator [](uint32_t index) const;
@@ -212,6 +217,23 @@ namespace Napi {
     void DefineProperties(const std::initializer_list<PropertyDescriptor>& properties);
     void DefineProperties(const std::vector<PropertyDescriptor>& properties);
     bool InstanceOf(const Function& constructor) const;
+  };
+
+  template <typename Key>
+  class PropertyLValue {
+  public:
+    operator Value() const;
+
+    // |ValueType| can be anything supported by Object::Set.
+    template <typename ValueType>
+    PropertyLValue& operator =(ValueType value);
+    PropertyLValue() = delete;
+  private:
+    PropertyLValue(Object object, Key key);
+    Object _object;
+    Key _key;
+
+    friend class Napi::Object;
   };
 
   template <typename T>

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+build/
+src/

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -1,0 +1,18 @@
+#include "napi.h"
+
+using namespace Napi;
+
+Value Test1(const CallbackInfo& info) {
+  auto env = info.Env();
+  Object obj = Object::New(env);
+
+  obj["foo"] = String::New(env, "bar");
+
+  return obj;
+}
+
+void Init(Env env, Object exports, Object module) {
+  exports.Set("test1", Function::New(env, Test1));
+}
+
+NODE_API_MODULE(addon, Init)

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -1,0 +1,13 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'include_dirs': ['<!(node -p \'require("../").include\')'],
+      'dependencies': ['<!(node -p \'require("../").gyp\')'],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES' }
+    }
+  ]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,5 @@
+'use strict';
+const binding = require('./build/Release/binding.node');
+const assert = require('assert');
+
+assert.deepStrictEqual(binding.test1(), { "foo": "bar" });


### PR DESCRIPTION
Hi all! :wave: I’ve decided to do a thing:

* 52c1aa9 makes it easier to create new functions (avoid compiler warnings about ambiguity when creating functions)
* 051eb13 adds support for `obj[key] = value` notation
* 4f2fe82 adds a small test for the 2 features mentioned above

Let me know what you think!