### PR TITLE
Minor Error handling refactor

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -1198,12 +1198,15 @@ inline Error::Error() : Object(), _message(nullptr) {
 inline Error::Error(napi_env env, napi_value value) : Object(env, value) {
 }
 
-inline std::string Error::Message() const {
+inline const std::string& Error::Message() const NAPI_NOEXCEPT {
   if (_message.size() == 0 && _env != nullptr) {
     try {
-      const_cast<Error*>(this)->_message = (*this)["message"].As<String>();
+      _message = (*this)["message"].As<String>();
     }
-    catch (const Error&) {
+    catch (...) {
+      // Catch all errors here, to include e.g. a std::bad_alloc from
+      // the std::string::operator=, because this is used by the
+      // Error::what() noexcept method.
     }
   }
   return _message;

--- a/napi.h
+++ b/napi.h
@@ -449,7 +449,7 @@ namespace Napi {
     Error();
     Error(napi_env env, napi_value value);
 
-    std::string Message() const;
+    const std::string& Message() const NAPI_NOEXCEPT;
     void ThrowAsJavaScriptException() const;
 
     const char* what() const NAPI_NOEXCEPT override;
@@ -464,7 +464,7 @@ namespace Napi {
                       create_error_fn create_error);
 
   private:
-    std::string _message;
+    mutable std::string _message;
   };
 
   class TypeError : public Error {


### PR DESCRIPTION
- Make `Error::Message()` a proper `noexcept` method because it is
  called by `what()`
- Mark the `_message` member of `Error` mutable instead of using
  a `const_cast`, this is what `mutable` is there for.