### PR TITLE
Pass through callback data and finalize hint

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -644,11 +644,53 @@ inline bool Object::InstanceOf(const Function& constructor) const {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T>
-inline External<T> External<T>::New(
-    napi_env env, T* data, napi_finalize finalizeCallback, void* finalizeHint) {
+inline External<T> External<T>::New(napi_env env, T* data) {
   napi_value value;
-  napi_status status = napi_create_external(env, data, finalizeCallback, finalizeHint, &value);
+  napi_status status = napi_create_external(env, data, nullptr, nullptr, &value);
   if (status != napi_ok) throw Error::New(env);
+  return External(env, value);
+}
+
+template <typename T>
+template <typename Finalizer>
+inline External<T> External<T>::New(napi_env env,
+                                    T* data,
+                                    Finalizer finalizeCallback) {
+  napi_value value;
+  details::FinalizeData<T, Finalizer>* finalizeData =
+    new details::FinalizeData<T, Finalizer>({ finalizeCallback, nullptr });
+  napi_status status = napi_create_external(
+    env,
+    data,
+    details::FinalizeData<T, Finalizer>::Wrapper,
+    finalizeData,
+    &value);
+  if (status != napi_ok) {
+    delete finalizeData;
+    throw Error::New(env);
+  }
+  return External(env, value);
+}
+
+template <typename T>
+template <typename Finalizer, typename Hint>
+inline External<T> External<T>::New(napi_env env,
+                                    T* data,
+                                    Finalizer finalizeCallback,
+                                    Hint* finalizeHint) {
+  napi_value value;
+  details::FinalizeData<T, Finalizer, Hint>* finalizeData =
+    new details::FinalizeData<T, Finalizer, Hint>({ finalizeCallback, finalizeHint });
+  napi_status status = napi_create_external(
+    env,
+    data,
+    details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
+    finalizeData,
+    &value);
+  if (status != napi_ok) {
+    delete finalizeData;
+    throw Error::New(env);
+  }
   return External(env, value);
 }
 
@@ -709,26 +751,65 @@ inline ArrayBuffer ArrayBuffer::New(napi_env env, size_t byteLength) {
   napi_status status = napi_create_arraybuffer(env, byteLength, &data, &value);
   if (status != napi_ok) throw Error::New(env);
 
-  ArrayBuffer arrayBuffer(env, value);
-  arrayBuffer._data = data;
-  arrayBuffer._length = byteLength;
-  return arrayBuffer;
+  return ArrayBuffer(env, value, data, byteLength);
 }
 
 inline ArrayBuffer ArrayBuffer::New(napi_env env,
                                     void* externalData,
-                                    size_t byteLength,
-                                    napi_finalize finalizeCallback,
-                                    void* finalizeHint) {
+                                    size_t byteLength) {
   napi_value value;
   napi_status status = napi_create_external_arraybuffer(
-    env, externalData, byteLength, finalizeCallback, finalizeHint, &value);
+    env, externalData, byteLength, nullptr, nullptr, &value);
   if (status != napi_ok) throw Error::New(env);
 
-  ArrayBuffer arrayBuffer(env, value);
-  arrayBuffer._data = externalData;
-  arrayBuffer._length = byteLength;
-  return arrayBuffer;
+  return ArrayBuffer(env, value, externalData, byteLength);
+}
+
+template <typename Finalizer>
+inline ArrayBuffer ArrayBuffer::New(napi_env env,
+                                    void* externalData,
+                                    size_t byteLength,
+                                    Finalizer finalizeCallback) {
+  napi_value value;
+  details::FinalizeData<void, Finalizer>* finalizeData =
+    new details::FinalizeData<void, Finalizer>({ finalizeCallback, nullptr });
+  napi_status status = napi_create_external_arraybuffer(
+    env,
+    externalData,
+    byteLength,
+    details::FinalizeData<void, Finalizer>::Wrapper,
+    finalizeData,
+    &value);
+  if (status != napi_ok) {
+    delete finalizeData;
+    throw Error::New(env);
+  }
+
+  return ArrayBuffer(env, value, externalData, byteLength);
+}
+
+template <typename Finalizer, typename Hint>
+inline ArrayBuffer ArrayBuffer::New(napi_env env,
+                                    void* externalData,
+                                    size_t byteLength,
+                                    Finalizer finalizeCallback,
+                                    Hint* finalizeHint) {
+  napi_value value;
+  details::FinalizeData<void, Finalizer, Hint>* finalizeData =
+    new details::FinalizeData<void, Finalizer, Hint>({ finalizeCallback, finalizeHint });
+  napi_status status = napi_create_external_arraybuffer(
+    env,
+    externalData,
+    byteLength,
+    details::FinalizeData<void, Finalizer, Hint>::WrapperWithHint,
+    finalizeData,
+    &value);
+  if (status != napi_ok) {
+    delete finalizeData;
+    throw Error::New(env);
+  }
+
+  return ArrayBuffer(env, value, externalData, byteLength);
 }
 
 inline ArrayBuffer::ArrayBuffer() : Object(), _data(nullptr), _length(0) {
@@ -738,12 +819,28 @@ inline ArrayBuffer::ArrayBuffer(napi_env env, napi_value value)
   : Object(env, value), _data(nullptr), _length(0) {
 }
 
+inline ArrayBuffer::ArrayBuffer(napi_env env, napi_value value, void* data, size_t length)
+  : Object(env, value), _data(data), _length(length) {
+}
+
 inline void* ArrayBuffer::Data() {
+  EnsureInfo();
   return _data;
 }
 
 inline size_t ArrayBuffer::ByteLength() {
+  EnsureInfo();
   return _length;
+}
+
+inline void ArrayBuffer::EnsureInfo() const {
+  // The ArrayBuffer instance may have been constructed from a napi_value whose
+  // length/data are not yet known. Fetch and cache these values just once,
+  // since they can never change during the lifetime of the ArrayBuffer.
+  if (_data == nullptr) {
+    napi_status status = napi_get_arraybuffer_info(_env, _value, &_data, &_length);
+    if (status != napi_ok) throw Error::New(_env);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -936,12 +1033,14 @@ struct CallbackData {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
         static_cast<CallbackData*>(callbackInfo.Data());
+      callbackInfo.SetData(callbackData->data);
       return callbackData->callback(callbackInfo);
     }
     NAPI_RETHROW_JS_ERROR(env)
   }
 
   Callable callback;
+  void* data;
 };
 
 template <typename Callable>
@@ -952,6 +1051,7 @@ struct CallbackData<Callable, void> {
       CallbackInfo callbackInfo(env, info);
       CallbackData* callbackData =
         static_cast<CallbackData*>(callbackInfo.Data());
+      callbackInfo.SetData(callbackData->data);
       callbackData->callback(callbackInfo);
       return nullptr;
     }
@@ -959,6 +1059,27 @@ struct CallbackData<Callable, void> {
   }
 
   Callable callback;
+  void* data;
+};
+
+template <typename T, typename Finalizer, typename Hint = void>
+struct FinalizeData {
+  static inline
+  void Wrapper(napi_env env, void* data, void* finalizeHint) {
+    FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
+    finalizeData->callback(Env(env), static_cast<T*>(data));
+    delete finalizeData;
+  }
+
+  static inline
+  void WrapperWithHint(napi_env env, void* data, void* finalizeHint) {
+    FinalizeData* finalizeData = static_cast<FinalizeData*>(finalizeHint);
+    finalizeData->callback(Env(env), static_cast<T*>(data), finalizeData->hint);
+    delete finalizeData;
+  }
+
+  Finalizer callback;
+  Hint* hint;
 };
 
 }  // namespace details
@@ -966,13 +1087,13 @@ struct CallbackData<Callable, void> {
 template <typename Callable>
 inline Function Function::New(napi_env env,
                               Callable cb,
-                              const char* utf8name) {
+                              const char* utf8name,
+                              void* data) {
   typedef decltype(cb(CallbackInfo(nullptr, nullptr))) ReturnType;
   typedef details::CallbackData<Callable, ReturnType> CbData;
   // TODO: Delete when the function is destroyed
-  auto callbackData = new CbData({ cb });
+  auto callbackData = new CbData({ cb, data });
 
-  // TODO: set the function name
   napi_value value;
   napi_status status = napi_create_function(
     env, utf8name, CbData::Wrapper, callbackData, &value);
@@ -983,8 +1104,9 @@ inline Function Function::New(napi_env env,
 template <typename Callable>
 inline Function Function::New(napi_env env,
                               Callable cb,
-                              const std::string& utf8name) {
-  return New(env, cb, utf8name.c_str());
+                              const std::string& utf8name,
+                              void* data) {
+  return New(env, cb, utf8name.c_str(), data);
 }
 
 inline Function::Function() : Object() {
@@ -1073,16 +1195,62 @@ inline Buffer<T> Buffer<T>::New(napi_env env, size_t length) {
   void* data;
   napi_status status = napi_create_buffer(env, length * sizeof (T), &data, &value);
   if (status != napi_ok) throw Error::New(env);
+  return Buffer(env, value, length, static_cast<T*>(data));
+}
+
+template <typename T>
+inline Buffer<T> Buffer<T>::New(napi_env env, T* data, size_t length) {
+  napi_value value;
+  napi_status status = napi_create_external_buffer(
+    env, length * sizeof (T), data, nullptr, nullptr, &value);
+  if (status != napi_ok) throw Error::New(env);
   return Buffer(env, value, length, data);
 }
 
 template <typename T>
-inline Buffer<T> Buffer<T>::New(
-    napi_env env, T* data, size_t length, napi_finalize finalizeCallback, void* finalizeHint) {
+template <typename Finalizer>
+inline Buffer<T> Buffer<T>::New(napi_env env,
+                                T* data,
+                                size_t length,
+                                Finalizer finalizeCallback) {
   napi_value value;
+  details::FinalizeData<T, Finalizer>* finalizeData =
+    new details::FinalizeData<T, Finalizer>({ finalizeCallback, nullptr });
   napi_status status = napi_create_external_buffer(
-    env, length * sizeof (T), data, finalizeCallback, finalizeHint, &value);
-  if (status != napi_ok) throw Error::New(env);
+    env,
+    length * sizeof (T),
+    data,
+    details::FinalizeData<T, Finalizer>::Wrapper,
+    finalizeData,
+    &value);
+  if (status != napi_ok) {
+    delete finalizeData;
+    throw Error::New(env);
+  }
+  return Buffer(env, value, length, data);
+}
+
+template <typename T>
+template <typename Finalizer, typename Hint>
+inline Buffer<T> Buffer<T>::New(napi_env env,
+                                T* data,
+                                size_t length,
+                                Finalizer finalizeCallback,
+                                Hint* finalizeHint) {
+  napi_value value;
+  details::FinalizeData<T, Finalizer, Hint>* finalizeData =
+    new details::FinalizeData<T, Finalizer, Hint>({ finalizeCallback, finalizeHint });
+  napi_status status = napi_create_external_buffer(
+    env,
+    length * sizeof (T),
+    data,
+    details::FinalizeData<T, Finalizer, Hint>::WrapperWithHint,
+    finalizeData,
+    &value);
+  if (status != napi_ok) {
+    delete finalizeData;
+    throw Error::New(env);
+  }
   return Buffer(env, value, length, data);
 }
 
@@ -1092,7 +1260,7 @@ inline Buffer<T> Buffer<T>::Copy(napi_env env, const T* data, size_t length) {
   napi_status status = napi_create_buffer_copy(
     env, length * sizeof (T), data, nullptr, &value);
   if (status != napi_ok) throw Error::New(env);
-  return Buffer(env, value);
+  return Buffer<T>(env, value);
 }
 
 template <typename T>

--- a/napi.h
+++ b/napi.h
@@ -239,10 +239,19 @@ namespace Napi {
   template <typename T>
   class External : public Value {
   public:
+    static External New(napi_env env, T* data);
+
+    // Finalizer must implement operator() accepting a T* and returning void.
+    template <typename Finalizer>
     static External New(napi_env env,
                         T* data,
-                        napi_finalize finalizeCallback = nullptr,
-                        void* finalizeHint = nullptr);
+                        Finalizer finalizeCallback);
+    // Finalizer must implement operator() accepting a T* and Hint* and returning void.
+    template <typename Finalizer, typename Hint>
+    static External New(napi_env env,
+                        T* data,
+                        Finalizer finalizeCallback,
+                        Hint* finalizeHint);
 
     External();
     External(napi_env env, napi_value value);
@@ -264,11 +273,21 @@ namespace Napi {
   class ArrayBuffer : public Object {
   public:
     static ArrayBuffer New(napi_env env, size_t byteLength);
+    static ArrayBuffer New(napi_env env, void* externalData, size_t byteLength);
+
+    // Finalizer must implement operator() accepting a void* and returning void.
+    template <typename Finalizer>
     static ArrayBuffer New(napi_env env,
                            void* externalData,
                            size_t byteLength,
-                           napi_finalize finalizeCallback = nullptr,
-                           void* finalizeHint = nullptr);
+                           Finalizer finalizeCallback);
+    // Finalizer must implement operator() accepting a void* and Hint* and returning void.
+    template <typename Finalizer, typename Hint>
+    static ArrayBuffer New(napi_env env,
+                           void* externalData,
+                           size_t byteLength,
+                           Finalizer finalizeCallback,
+                           Hint* finalizeHint);
 
     ArrayBuffer();
     ArrayBuffer(napi_env env, napi_value value);
@@ -277,8 +296,11 @@ namespace Napi {
     size_t ByteLength();
 
   private:
-    void* _data;
-    size_t _length;
+    mutable void* _data;
+    mutable size_t _length;
+
+    ArrayBuffer(napi_env env, napi_value value, void* data, size_t length);
+    void EnsureInfo() const;
   };
 
   class TypedArray : public Object {
@@ -344,11 +366,13 @@ namespace Napi {
     template <typename Callable>
     static Function New(napi_env env,
                         Callable cb,
-                        const char* utf8name = nullptr);
+                        const char* utf8name = nullptr,
+                        void* data = nullptr);
     template <typename Callable>
     static Function New(napi_env env,
                         Callable cb,
-                        const std::string& utf8name);
+                        const std::string& utf8name,
+                        void* data = nullptr);
 
     Function();
     Function(napi_env env, napi_value value);
@@ -373,10 +397,20 @@ namespace Napi {
   class Buffer : public Object {
   public:
     static Buffer<T> New(napi_env env, size_t length);
+    static Buffer<T> New(napi_env env, T* data, size_t length);
+
+    // Finalizer must implement operator() accepting a T* and returning void.
+    template <typename Finalizer>
     static Buffer<T> New(napi_env env, T* data,
                          size_t length,
-                         napi_finalize finalizeCallback = nullptr,
-                         void* finalizeHint = nullptr);
+                         Finalizer finalizeCallback);
+    // Finalizer must implement operator() accepting a T* and Hint* and returning void.
+    template <typename Finalizer, typename Hint>
+    static Buffer<T> New(napi_env env, T* data,
+                         size_t length,
+                         Finalizer finalizeCallback,
+                         Hint* finalizeHint);
+
     static Buffer<T> Copy(napi_env env, const T* data, size_t length);
 
     Buffer();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "pretest": "node-gyp rebuild -C test",
-    "test": "node test"
+    "test": "node --expose-gc test"
   },
   "version": "0.1.0"
 }

--- a/test/arraybuffer.cc
+++ b/test/arraybuffer.cc
@@ -1,0 +1,137 @@
+#include "napi.h"
+
+using namespace Napi;
+
+namespace {
+
+const size_t testLength = 4;
+uint8_t testData[testLength];
+int finalizeCount = 0;
+
+void InitData(uint8_t* data, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    data[i] = static_cast<uint8_t>(i);
+  }
+}
+
+bool VerifyData(uint8_t* data, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    if (data[i] != static_cast<uint8_t>(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Value CreateBuffer(const CallbackInfo& info) {
+  ArrayBuffer buffer = ArrayBuffer::New(info.Env(), testLength);
+
+  if (buffer.ByteLength() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  InitData(static_cast<uint8_t*>(buffer.Data()), testLength);
+  return buffer;
+}
+
+Value CreateExternalBuffer(const CallbackInfo& info) {
+  ArrayBuffer buffer = ArrayBuffer::New(info.Env(), testData, testLength);
+
+  if (buffer.ByteLength() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() != testData) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+
+  InitData(testData, testLength);
+  return buffer;
+}
+
+Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
+  uint8_t* data = new uint8_t[testLength];
+
+  ArrayBuffer buffer = ArrayBuffer::New(
+    info.Env(),
+    data,
+    testLength,
+    [](Env env, void* finalizeData) {
+      delete[] finalizeData;
+      finalizeCount++;
+    });
+
+  if (buffer.ByteLength() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() != data) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+
+  InitData(data, testLength);
+  return buffer;
+}
+
+Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
+  uint8_t* data = new uint8_t[testLength];
+
+  char* hint = nullptr;
+  ArrayBuffer buffer = ArrayBuffer::New(
+    info.Env(),
+    data,
+    testLength,
+    [](Env env, void* finalizeData, char* finalizeHint) {
+      delete[] finalizeData;
+      finalizeCount++;
+    },
+    hint);
+
+  if (buffer.ByteLength() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() != data) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+
+  InitData(data, testLength);
+  return buffer;
+}
+
+void CheckBuffer(const CallbackInfo& info) {
+  if (!info[0].IsArrayBuffer()) {
+    throw Error::New(info.Env(), "A buffer was expected.");
+  }
+
+  ArrayBuffer buffer = info[0].As<ArrayBuffer>();
+
+  if (buffer.ByteLength() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (!VerifyData(static_cast<uint8_t*>(buffer.Data()), testLength)) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+}
+
+Value GetFinalizeCount(const CallbackInfo& info) {
+   return Number::New(info.Env(), finalizeCount);
+}
+
+} // end anonymous namespace
+
+Object InitArrayBuffer(Env env) {
+  Object exports = Object::New(env);
+
+  exports["createBuffer"] = Function::New(env, CreateBuffer);
+  exports["createExternalBuffer"] = Function::New(env, CreateExternalBuffer);
+  exports["createExternalBufferWithFinalize"] =
+    Function::New(env, CreateExternalBufferWithFinalize);
+  exports["createExternalBufferWithFinalizeHint"] =
+    Function::New(env, CreateExternalBufferWithFinalizeHint);
+  exports["checkBuffer"] = Function::New(env, CheckBuffer);
+  exports["getFinalizeCount"] = Function::New(env, GetFinalizeCount);
+
+  return exports;
+}

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -1,0 +1,31 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const binding = require(`./build/${buildType}/binding.node`);
+const assert = require('assert');
+
+let test = binding.arraybuffer.createBuffer();
+binding.arraybuffer.checkBuffer(test);
+assert.ok(test instanceof ArrayBuffer);
+
+let test2 = test.slice(0);
+binding.arraybuffer.checkBuffer(test2);
+
+test = binding.arraybuffer.createExternalBuffer();
+binding.arraybuffer.checkBuffer(test);
+assert.ok(test instanceof ArrayBuffer);
+
+test = binding.arraybuffer.createExternalBufferWithFinalize();
+binding.arraybuffer.checkBuffer(test);
+assert.ok(test instanceof ArrayBuffer);
+assert.strictEqual(0, binding.arraybuffer.getFinalizeCount());
+test = null;
+global.gc();
+assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
+
+test = binding.arraybuffer.createExternalBufferWithFinalizeHint();
+binding.arraybuffer.checkBuffer(test);
+assert.ok(test instanceof ArrayBuffer);
+assert.strictEqual(1, binding.arraybuffer.getFinalizeCount());
+test = null;
+global.gc();
+assert.strictEqual(2, binding.arraybuffer.getFinalizeCount());

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -2,11 +2,17 @@
 
 using namespace Napi;
 
+Object InitArrayBuffer(Env env);
+Object InitBuffer(Env env);
 Object InitError(Env env);
+Object InitExternal(Env env);
 Object InitFunction(Env env);
 
 void Init(Env env, Object exports, Object module) {
+  exports.Set("arraybuffer", InitArrayBuffer(env));
+  exports.Set("buffer", InitBuffer(env));
   exports.Set("error", InitError(env));
+  exports.Set("external", InitExternal(env));
   exports.Set("function", InitFunction(env));
 }
 

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -3,8 +3,11 @@
     {
       'target_name': 'binding',
       'sources': [
+        'arraybuffer.cc',
         'binding.cc',
+        'buffer.cc',
         'error.cc',
+        'external.cc',
         'function.cc',
       ],
       'include_dirs': ["<!(node -p \"require('../').include\")"],

--- a/test/buffer.cc
+++ b/test/buffer.cc
@@ -1,0 +1,164 @@
+#include "napi.h"
+
+using namespace Napi;
+
+namespace {
+
+const size_t testLength = 4;
+uint16_t testData[testLength];
+int finalizeCount = 0;
+
+template <typename T>
+void InitData(T* data, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    data[i] = static_cast<T>(i);
+  }
+}
+
+template <typename T>
+bool VerifyData(T* data, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    if (data[i] != static_cast<T>(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Value CreateBuffer(const CallbackInfo& info) {
+  Buffer<uint16_t> buffer = Buffer<uint16_t>::New(info.Env(), testLength);
+
+  if (buffer.Length() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  InitData(buffer.Data(), testLength);
+  return buffer;
+}
+
+Value CreateExternalBuffer(const CallbackInfo& info) {
+  Buffer<uint16_t> buffer = Buffer<uint16_t>::New(
+    info.Env(),
+    testData,
+    testLength);
+
+  if (buffer.Length() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() != testData) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+
+  InitData(testData, testLength);
+  return buffer;
+}
+
+Value CreateExternalBufferWithFinalize(const CallbackInfo& info) {
+  uint16_t* data = new uint16_t[testLength];
+
+  Buffer<uint16_t> buffer = Buffer<uint16_t>::New(
+    info.Env(),
+    data,
+    testLength,
+    [](Env env, uint16_t* finalizeData) {
+      delete[] finalizeData;
+      finalizeCount++;
+    });
+
+  if (buffer.Length() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() != data) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+
+  InitData(data, testLength);
+  return buffer;
+}
+
+Value CreateExternalBufferWithFinalizeHint(const CallbackInfo& info) {
+  uint16_t* data = new uint16_t[testLength];
+
+  char* hint = nullptr;
+  Buffer<uint16_t> buffer = Buffer<uint16_t>::New(
+    info.Env(),
+    data,
+    testLength,
+    [](Env env, uint16_t* finalizeData, char* finalizeHint) {
+      delete[] finalizeData;
+      finalizeCount++;
+    },
+    hint);
+
+  if (buffer.Length() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() != data) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+
+  InitData(data, testLength);
+  return buffer;
+}
+
+Value CreateBufferCopy(const CallbackInfo& info) {
+  InitData(testData, testLength);
+
+  Buffer<uint16_t> buffer = Buffer<uint16_t>::Copy(
+    info.Env(), testData, testLength);
+
+  if (buffer.Length() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (buffer.Data() == testData) {
+    throw Error::New(info.Env(), "Copy should have different memory.");
+  }
+
+  if (!VerifyData(buffer.Data(), buffer.Length())) {
+    throw Error::New(info.Env(), "Copy data is incorrect.");
+  }
+
+  return buffer;
+}
+
+void CheckBuffer(const CallbackInfo& info) {
+  if (!info[0].IsBuffer()) {
+    throw Error::New(info.Env(), "A buffer was expected.");
+  }
+
+  Buffer<uint16_t> buffer = info[0].As<Buffer<uint16_t>>();
+
+  if (buffer.Length() != testLength) {
+    throw Error::New(info.Env(), "Incorrect buffer length.");
+  }
+
+  if (!VerifyData(buffer.Data(), testLength)) {
+    throw Error::New(info.Env(), "Incorrect buffer data.");
+  }
+}
+
+Value GetFinalizeCount(const CallbackInfo& info) {
+   return Number::New(info.Env(), finalizeCount);
+}
+
+} // end anonymous namespace
+
+Object InitBuffer(Env env) {
+  Object exports = Object::New(env);
+
+  exports["createBuffer"] = Function::New(env, CreateBuffer);
+  exports["createExternalBuffer"] = Function::New(env, CreateExternalBuffer);
+  exports["createExternalBufferWithFinalize"] =
+    Function::New(env, CreateExternalBufferWithFinalize);
+  exports["createExternalBufferWithFinalizeHint"] =
+    Function::New(env, CreateExternalBufferWithFinalizeHint);
+  exports["createBufferCopy"] = Function::New(env, CreateBufferCopy);
+  exports["checkBuffer"] = Function::New(env, CheckBuffer);
+  exports["getFinalizeCount"] = Function::New(env, GetFinalizeCount);
+
+  return exports;
+}

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -1,0 +1,36 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const binding = require(`./build/${buildType}/binding.node`);
+const assert = require('assert');
+
+let test = binding.buffer.createBuffer();
+binding.buffer.checkBuffer(test);
+assert.ok(test instanceof Buffer);
+
+let test2 = Buffer.alloc(test.length);
+test.copy(test2);
+binding.buffer.checkBuffer(test2);
+
+test = binding.buffer.createBufferCopy();
+binding.buffer.checkBuffer(test);
+assert.ok(test instanceof Buffer);
+
+test = binding.buffer.createExternalBuffer();
+binding.buffer.checkBuffer(test);
+assert.ok(test instanceof Buffer);
+
+test = binding.buffer.createExternalBufferWithFinalize();
+binding.buffer.checkBuffer(test);
+assert.ok(test instanceof Buffer);
+assert.strictEqual(0, binding.buffer.getFinalizeCount());
+test = null;
+global.gc();
+assert.strictEqual(1, binding.buffer.getFinalizeCount());
+
+test = binding.buffer.createExternalBufferWithFinalizeHint();
+binding.buffer.checkBuffer(test);
+assert.ok(test instanceof Buffer);
+assert.strictEqual(1, binding.buffer.getFinalizeCount());
+test = null;
+global.gc();
+assert.strictEqual(2, binding.buffer.getFinalizeCount());

--- a/test/error.cc
+++ b/test/error.cc
@@ -2,6 +2,8 @@
 
 using namespace Napi;
 
+namespace {
+
 void ThrowError(const CallbackInfo& info) {
   std::string message = info[0].As<String>().Utf8Value();
   throw Error::New(info.Env(), message);
@@ -52,6 +54,8 @@ void CatchAndRethrowError(const CallbackInfo& info) {
      throw e;
   }
 }
+
+} // end anonymous namespace
 
 Object InitError(Env env) {
   Object exports = Object::New(env);

--- a/test/external.js
+++ b/test/external.js
@@ -1,0 +1,27 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const binding = require(`./build/${buildType}/binding.node`);
+const assert = require('assert');
+
+assert.strictEqual(0, binding.external.getFinalizeCount());
+
+let test = binding.external.createExternal();
+assert.strictEqual(typeof test, 'object');
+binding.external.checkExternal(test);
+test = null;
+global.gc();
+assert.strictEqual(0, binding.external.getFinalizeCount());
+
+test = binding.external.createExternalWithFinalize();
+assert.strictEqual(typeof test, 'object');
+binding.external.checkExternal(test);
+test = null;
+global.gc();
+assert.strictEqual(1, binding.external.getFinalizeCount());
+
+test = binding.external.createExternalWithFinalizeHint();
+assert.strictEqual(typeof test, 'object');
+binding.external.checkExternal(test);
+test = null;
+global.gc();
+assert.strictEqual(2, binding.external.getFinalizeCount());

--- a/test/function.cc
+++ b/test/function.cc
@@ -2,6 +2,10 @@
 
 using namespace Napi;
 
+namespace {
+
+int testData = 1;
+
 void VoidCallback(const CallbackInfo& info) {
   auto env = info.Env();
   Object obj = info[0].As<Object>();
@@ -14,6 +18,28 @@ Value ValueCallback(const CallbackInfo& info) {
   Object obj = Object::New(env);
 
   obj["foo"] = String::New(env, "bar");
+
+  return obj;
+}
+
+void VoidCallbackWithData(const CallbackInfo& info) {
+  auto env = info.Env();
+  Object obj = info[0].As<Object>();
+
+  obj["foo"] = String::New(env, "bar");
+
+  int* data = static_cast<int*>(info.Data());
+  obj["data"] = Number::New(env, *data);
+}
+
+Value ValueCallbackWithData(const CallbackInfo& info) {
+  auto env = info.Env();
+  Object obj = Object::New(env);
+
+  obj["foo"] = String::New(env, "bar");
+
+  int* data = static_cast<int*>(info.Data());
+  obj["data"] = Number::New(env, *data);
 
   return obj;
 }
@@ -65,10 +91,16 @@ Value CallConstructorWithVector(const CallbackInfo& info) {
    return func.New(args);
 }
 
+} // end anonymous namespace
+
 Object InitFunction(Env env) {
   Object exports = Object::New(env);
   exports["voidCallback"] = Function::New(env, VoidCallback, "voidCallback");
   exports["valueCallback"] = Function::New(env, ValueCallback, std::string("valueCallback"));
+  exports["voidCallbackWithData"] =
+    Function::New(env, VoidCallbackWithData, nullptr, &testData);
+  exports["valueCallbackWithData"] =
+    Function::New(env, ValueCallbackWithData, nullptr, &testData);
   exports["callWithArgs"] = Function::New(env, CallWithArgs);
   exports["callWithVector"] = Function::New(env, CallWithVector);
   exports["callWithReceiverAndArgs"] = Function::New(env, CallWithReceiverAndArgs);

--- a/test/function.js
+++ b/test/function.js
@@ -49,6 +49,12 @@ obj = binding.function.callConstructorWithVector(testConstructor, 6, 7, 8);
 assert(obj instanceof testConstructor);
 assert.deepStrictEqual(args, [ 6, 7, 8 ]);
 
+obj = {};
+assert.deepStrictEqual(binding.function.voidCallbackWithData(obj), undefined);
+assert.deepStrictEqual(obj, { "foo": "bar", "data": 1 });
+
+assert.deepStrictEqual(binding.function.valueCallbackWithData(), { "foo": "bar", "data": 1 });
+
 assert.equal(binding.function.voidCallback.name, 'voidCallback');
 assert.equal(binding.function.valueCallback.name, 'valueCallback');
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,14 @@
 'use strict';
 
+if (typeof global.gc !== 'function') {
+   throw new Error('Tests require --expose-gc flag.')
+}
+
 let testModules = [
+   'arraybuffer',
+   'buffer',
    'error',
+   'external',
    'function',
 ];
 


### PR DESCRIPTION
 - Add optional callback data pointer to `Function::New()`
 - Add overloads to all `New` methods that take a finalizer callback, to support templatized finalizer and finalize hint
 - Add tests for `ArrayBuffer`, `Buffer`, `External`, and `Function` classes to verify the changed areas of code
 - Fix bug in `ArrayBuffer` class found by tests (copy `EnsureInfo` pattern from `Buffer`)

Note that while the finalize hint parameter is templatized, the function callback data parameter is still just a `void*`.  I considered applying the a similar pattern there, but it started to get way too complicated. The challenge is the callback data becomes a property on the `CallbackInfo` class, so then that class would have to be templatized also. But that class is also used in the various method callbacks in `ObjectWrap`, which already have templatized typedefs in the `ObjectWrap` class and are complicated enough already. Assuming that the callback data parameter would be rarely used in C++ (since lambda captures offer a more convenient alternative), I didn't think all the added complexity would be justified.