### PR TITLE
Add PropertyDescriptor creation methods

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -152,7 +152,7 @@ namespace Napi {
   };
 
   class Name : public Value {
-  protected:
+  public:
     Name();
     Name(napi_env env, napi_value value);
   };
@@ -685,10 +685,87 @@ namespace Napi {
 
   class PropertyDescriptor {
   public:
-    PropertyDescriptor(napi_property_descriptor desc) : _desc(desc) {}
+    template <typename Getter>
+    static PropertyDescriptor Accessor(const char* utf8name,
+                                       Getter getter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter>
+    static PropertyDescriptor Accessor(const std::string& utf8name,
+                                       Getter getter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter>
+    static PropertyDescriptor Accessor(napi_value name,
+                                       Getter getter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter>
+    static PropertyDescriptor Accessor(Name name,
+                                       Getter getter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter, typename Setter>
+    static PropertyDescriptor Accessor(const char* utf8name,
+                                       Getter getter,
+                                       Setter setter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter, typename Setter>
+    static PropertyDescriptor Accessor(const std::string& utf8name,
+                                       Getter getter,
+                                       Setter setter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter, typename Setter>
+    static PropertyDescriptor Accessor(napi_value name,
+                                       Getter getter,
+                                       Setter setter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Getter, typename Setter>
+    static PropertyDescriptor Accessor(Name name,
+                                       Getter getter,
+                                       Setter setter,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Callable>
+    static PropertyDescriptor Function(const char* utf8name,
+                                       Callable cb,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Callable>
+    static PropertyDescriptor Function(const std::string& utf8name,
+                                       Callable cb,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Callable>
+    static PropertyDescriptor Function(napi_value name,
+                                       Callable cb,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    template <typename Callable>
+    static PropertyDescriptor Function(Name name,
+                                       Callable cb,
+                                       napi_property_attributes attributes = napi_default,
+                                       void* data = nullptr);
+    static PropertyDescriptor Value(const char* utf8name,
+                                    napi_value value,
+                                    napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor Value(const std::string& utf8name,
+                                    napi_value value,
+                                    napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor Value(napi_value name,
+                                    napi_value value,
+                                    napi_property_attributes attributes = napi_default);
+    static PropertyDescriptor Value(Name name,
+                                    Napi::Value value,
+                                    napi_property_attributes attributes = napi_default);
 
-    operator napi_property_descriptor&() { return _desc; }
-    operator const napi_property_descriptor&() const { return _desc; }
+    PropertyDescriptor(napi_property_descriptor desc);
+
+    operator napi_property_descriptor&();
+    operator const napi_property_descriptor&() const;
 
   private:
     napi_property_descriptor _desc;

--- a/test/binding.cc
+++ b/test/binding.cc
@@ -8,6 +8,7 @@ Object InitError(Env env);
 Object InitExternal(Env env);
 Object InitFunction(Env env);
 Object InitName(Env env);
+Object InitObject(Env env);
 
 void Init(Env env, Object exports, Object module) {
   exports.Set("arraybuffer", InitArrayBuffer(env));
@@ -16,6 +17,7 @@ void Init(Env env, Object exports, Object module) {
   exports.Set("external", InitExternal(env));
   exports.Set("function", InitFunction(env));
   exports.Set("name", InitName(env));
+  exports.Set("object", InitObject(env));
 }
 
 NODE_API_MODULE(addon, Init)

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -10,6 +10,7 @@
         'external.cc',
         'function.cc',
         'name.cc',
+        'object.cc',
       ],
       'include_dirs': ["<!(node -p \"require('../').include\")"],
       'dependencies': ["<!(node -p \"require('../').gyp\")"],

--- a/test/object.cc
+++ b/test/object.cc
@@ -1,0 +1,80 @@
+#include "napi.h"
+
+using namespace Napi;
+
+static bool testValue = true;
+
+Value TestGetter(const CallbackInfo& info) {
+   return Boolean::New(info.Env(), testValue);
+}
+
+void TestSetter(const CallbackInfo& info) {
+   testValue = info[0].As<Boolean>();
+}
+
+Value TestFunction(const CallbackInfo& info) {
+   return Boolean::New(info.Env(), true);
+}
+
+void DefineProperties(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  String nameType = info[1].As<String>();
+
+  Boolean trueValue = Boolean::New(info.Env(), true);
+
+  if (nameType.Utf8Value() == "literal") {
+    obj.DefineProperties({
+      PropertyDescriptor::Accessor("readonlyAccessor", TestGetter),
+      PropertyDescriptor::Accessor("readwriteAccessor", TestGetter, TestSetter),
+      PropertyDescriptor::Value("readonlyValue", trueValue),
+      PropertyDescriptor::Value("readwriteValue", trueValue, napi_writable),
+      PropertyDescriptor::Value("enumerableValue", trueValue, napi_enumerable),
+      PropertyDescriptor::Value("configurableValue", trueValue, napi_configurable),
+      PropertyDescriptor::Function("function", TestFunction),
+    });
+  } else if (nameType.Utf8Value() == "string") {
+    obj.DefineProperties({
+      PropertyDescriptor::Accessor(std::string("readonlyAccessor"), TestGetter),
+      PropertyDescriptor::Accessor(std::string("readwriteAccessor"), TestGetter, TestSetter),
+      PropertyDescriptor::Value(std::string("readonlyValue"), trueValue),
+      PropertyDescriptor::Value(std::string("readwriteValue"), trueValue, napi_writable),
+      PropertyDescriptor::Value(std::string("enumerableValue"), trueValue, napi_enumerable),
+      PropertyDescriptor::Value(std::string("configurableValue"), trueValue, napi_configurable),
+      PropertyDescriptor::Function(std::string("function"), TestFunction),
+    });
+  } else if (nameType.Utf8Value() == "value") {
+    obj.DefineProperties({
+      PropertyDescriptor::Accessor(
+        Napi::String::New(info.Env(), "readonlyAccessor"), TestGetter),
+      PropertyDescriptor::Accessor(
+        Napi::String::New(info.Env(), "readwriteAccessor"), TestGetter, TestSetter),
+      PropertyDescriptor::Value(
+        Napi::String::New(info.Env(), "readonlyValue"), trueValue),
+      PropertyDescriptor::Value(
+        Napi::String::New(info.Env(), "readwriteValue"), trueValue, napi_writable),
+      PropertyDescriptor::Value(
+        Napi::String::New(info.Env(), "enumerableValue"), trueValue, napi_enumerable),
+      PropertyDescriptor::Value(
+        Napi::String::New(info.Env(), "configurableValue"), trueValue, napi_configurable),
+      PropertyDescriptor::Function(
+        Napi::String::New(info.Env(), "function"), TestFunction),
+    });
+  }
+}
+
+void DefineValueProperty(const CallbackInfo& info) {
+  Object obj = info[0].As<Object>();
+  Name name = info[1].As<Name>();
+  Value value = info[2];
+
+  obj.DefineProperty(PropertyDescriptor::Value(name, value));
+}
+
+Object InitObject(Env env) {
+  Object exports = Object::New(env);
+
+  exports["defineProperties"] = Function::New(env, DefineProperties);
+  exports["defineValueProperty"] = Function::New(env, DefineValueProperty);
+
+  return exports;
+}

--- a/test/object.js
+++ b/test/object.js
@@ -1,0 +1,71 @@
+'use strict';
+const buildType = process.config.target_defaults.default_configuration;
+const binding = require(`./build/${buildType}/binding.node`);
+const assert = require('assert');
+
+function assertPropertyIs(obj, key, attribute) {
+   const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+   assert.ok(propDesc);
+   assert.ok(propDesc[attribute]);
+}
+
+function assertPropertyIsNot(obj, key, attribute) {
+   const propDesc = Object.getOwnPropertyDescriptor(obj, key);
+   assert.ok(propDesc);
+   assert.ok(!propDesc[attribute]);
+}
+
+function testDefineProperties(nameType) {
+  const obj = {};
+  binding.object.defineProperties(obj, nameType);
+
+  assertPropertyIsNot(obj, 'readonlyAccessor', 'writable');
+  assertPropertyIsNot(obj, 'readonlyAccessor', 'enumerable');
+  assertPropertyIsNot(obj, 'readonlyAccessor', 'configurable');
+  assert.strictEqual(obj.readonlyAccessor, true);
+
+  assertPropertyIs(obj, 'readwriteAccessor', 'writable');
+  assertPropertyIsNot(obj, 'readwriteAccessor', 'enumerable');
+  assertPropertyIsNot(obj, 'readwriteAccessor', 'configurable');
+  obj.readwriteAccessor = false;
+  assert.strictEqual(obj.readwriteAccessor, false);
+  obj.readwriteAccessor = true;
+  assert.strictEqual(obj.readwriteAccessor, true);
+
+  assertPropertyIsNot(obj, 'readonlyValue', 'writable');
+  assertPropertyIsNot(obj, 'readonlyValue', 'enumerable');
+  assertPropertyIsNot(obj, 'readonlyValue', 'configurable');
+  assert.strictEqual(obj.readonlyValue, true);
+
+  assertPropertyIs(obj, 'readwriteValue', 'writable');
+  assertPropertyIsNot(obj, 'readwriteValue', 'enumerable');
+  assertPropertyIsNot(obj, 'readwriteValue', 'configurable');
+  obj.readwriteValue = false;
+  assert.strictEqual(obj.readwriteValue, false);
+  obj.readwriteValue = true;
+  assert.strictEqual(obj.readwriteValue, true);
+
+  assertPropertyIsNot(obj, 'enumerableValue', 'writable');
+  assertPropertyIs(obj, 'enumerableValue', 'enumerable');
+  assertPropertyIsNot(obj, 'enumerableValue', 'configurable');
+
+  assertPropertyIsNot(obj, 'configurableValue', 'writable');
+  assertPropertyIsNot(obj, 'configurableValue', 'enumerable');
+  assertPropertyIs(obj, 'configurableValue', 'configurable');
+
+  assertPropertyIsNot(obj, 'function', 'writable');
+  assertPropertyIsNot(obj, 'function', 'enumerable');
+  assertPropertyIsNot(obj, 'function', 'configurable');
+  assert.strictEqual(obj.function(), true);
+}
+
+testDefineProperties('literal');
+testDefineProperties('string');
+testDefineProperties('value');
+
+{
+  const obj = {};
+  const testSym = Symbol();
+  binding.object.defineValueProperty(obj, testSym, 1);
+  assert.strictEqual(obj[testSym], 1);
+}


### PR DESCRIPTION
Add static methods on the `Napi::PropertyDescriptor` class that provide convenient ways to construct `PropertyDescriptor` instances for different kinds of property descriptors. These are equivalent to the similar static methods on the `ObjectWrap` class, except they are for use when defining properties outside of an object-wrapping scenario. Callbacks are templatized (like with `Function::New()`) so that they can work with lambdas or regular function pointers.

New test cases cover the various overloads for constructing property descriptors and defining properties.

And the `Name` class constructors needed to be made public, to allow code like `value.As<Name>()`, that is used by the test.