### PR TITLE
Prepare for publish to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/test/
+.npmignore

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+The MIT License (MIT)
+=====================
+
+Copyright (c) 2017 Node.js API collaborators
+-----------------------------------
+
+*Node.js API collaborators listed at <https://github.com/nodejs/node-api#collaborators>*
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ backward-compatibility with use with older versions of Node.js that do
 not have N-API built-in.
 
 To use N-API in a native module:
-  1. Add a dependency on this package to `package.json`.
-  It is not yet published to npm, so reference it directly from GitHub.
+  1. Add a dependency on this package to `package.json`:
 ```json
   "dependencies": {
-    "node-api": "github:nodejs/node-api",
+    "node-addon-api": "github:nodejs/node-addon-api",
   }
 ```
 
   2. Reference this package's include directory and gyp file in `binding.gyp`:
 ```gyp
-  'include_dirs': ["<!(node -p \"require('node-api').include\")"],
-  'dependencies': ["<!(node -p \"require('node-api').gyp\")"],
+  'include_dirs': ["<!(node -p \"require('node-addon-api').include\")"],
+  'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
 ```
 
   3. Ensure C++ exceptions are enabled in `binding.gyp`.
@@ -33,13 +32,30 @@ To use N-API in a native module:
 ```
 
   4. Include `napi.h` in the native module code.
-     To ensure only ABI-stable APIs are used, DO NOT include `node.h` or `v8.h`.
+     To ensure only ABI-stable APIs are used, DO NOT include
+     `node.h`, `nan.h`, or `v8.h`.
 ```C++
 #include "napi.h"
 ```
 
-At build time, the N-API back-compat library code will be used only when the targeted node version *does not* have N-API built-in.
+At build time, the N-API back-compat library code will be used only when the
+targeted node version *does not* have N-API built-in.
 
 See the [main project README](
    https://github.com/nodejs/abi-stable-node/blob/doc/README.md)
+or [preliminary documentation](https://github.com/nodejs/node/blob/v8.x/doc/api/n-api.md)
 for more details about N-API.
+
+<a name="collaborators"></a>
+### WG Members / Collaborators
+| Name                | GitHub link                                            |
+| ------------------- | ------------------------------------------------------ |
+| Anna Henningsen     | [@addaleax](https://github.com/addaleax)               |
+| Arunesh Chandra     | [@aruneshchandra](https://github.com/aruneshchandra)   |
+| Benjamin Byholm     | [@kkoopa](https://github.com/kkoopa)                   |
+| Gabriel Schulhof    | [@gabrielschulhof](https://github.com/gabrielschulhof) |
+| Hitesh Kanwathirtha | [@digitalinfinity](https://github.com/digitalinfinity) |
+| Jason Ginchereau    | [@jasongin](https://github.com/jasongin)               |
+| Michael Dawson      | [@mhdawson](https://github.com/mhdawson)               |
+| Sampson Gao         | [@sampsongao](https://github.com/sampsongao)           |
+| Taylor Woll         | [@boingoing](https://github.com/boingoing)             |

--- a/napi-inl.h
+++ b/napi-inl.h
@@ -2,10 +2,12 @@
 #define SRC_NAPI_INL_H_
 
 ////////////////////////////////////////////////////////////////////////////////
-// NAPI C++ Wrapper Classes
+// N-API C++ Wrapper Classes
 //
-// Inline header-only implementations for "NAPI" ABI-stable C APIs for Node.js.
+// Inline header-only implementations for "N-API" ABI-stable C APIs for Node.js.
 ////////////////////////////////////////////////////////////////////////////////
+
+// Note: Do not include this file directly! Include "napi.h" instead.
 
 #include <cassert>
 #include <cstring>

--- a/napi.h
+++ b/napi.h
@@ -2,9 +2,9 @@
 #define SRC_NAPI_H_
 
 ////////////////////////////////////////////////////////////////////////////////
-// NAPI C++ Wrapper Classes
+// N-API C++ Wrapper Classes
 //
-// These classes wrap the "NAPI" ABI-stable C APIs for Node.js, providing a
+// These classes wrap the "N-API" ABI-stable C APIs for Node.js, providing a
 // C++ object model and C++ exception-handling semantics with low overhead.
 // The wrappers are all header-only so that they do not affect the ABI.
 ////////////////////////////////////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -2,6 +2,17 @@
   "bugs": {
     "url": "https://github.com/nodejs/node-api/issues"
   },
+  "contributors": [
+    "Anna Henningsen (https://github.com/addaleax)",
+    "Arunesh Chandra (https://github.com/aruneshchandra)",
+    "Benjamin Byholm (https://github.com/kkoopa)",
+    "Gabriel Schulhof (https://github.com/gabrielschulhof)",
+    "Hitesh Kanwathirtha (https://github.com/digitalinfinity)",
+    "Jason Ginchereau (https://github.com/jasongin)",
+    "Michael Dawson (https://github.com/mhdawson)",
+    "Sampson Gao (https://github.com/sampsongao)",
+    "Taylor Woll (https://github.com/boingoing)"
+  ],
   "dependencies": {},
   "description": "Node.js API (N-API)",
   "devDependencies": {
@@ -11,7 +22,7 @@
   "homepage": "https://github.com/nodejs/node-api",
   "license": "MIT",
   "main": "index.js",
-  "name": "node-api",
+  "name": "node-addon-api",
   "optionalDependencies": {},
   "readme": "README.md",
   "repository": {


### PR DESCRIPTION
 - Change package name from "node-api" to "node-addon-api"
 - Add license file
 - Add contributors list to package.json and readme
 - Add preliminary doc link to readme