### PR TITLE
Fix some build failures

### DIFF
--- a/napi.h
+++ b/napi.h
@@ -1011,7 +1011,7 @@ namespace Napi {
 
     virtual void Execute() = 0;
     virtual void OnOK();
-    virtual void OnError(Error& e);
+    virtual void OnError(const Error& e);
 
     void SetError(const std::string& error);
 


### PR DESCRIPTION
- Move the `details` namespace to the top of `napi-inl.h`, because
  its declarations need to be present for some of its contents to
  be used (`FinalizeData` in particular)
- Make `AsyncWorker::OnError` take a const `Error` reference, because
  right now `AsyncWorker::OnWorkComplete` calls it with an rvalue ref
  and `OnError` doesn’t need any non-const methods of `Error`.
- Remove a `HandleScope` from `Error::New`, because the `HandleScope`
  constructor itself must be able to create an `Error` when handle scope
  creation fails.